### PR TITLE
Reduserer bundle størrelsen ved å bruke terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-query": "3.34.7",
+        "rollup-plugin-terser": "7.0.2",
         "vite-plugin-css-injected-by-js": "1.4.0"
       },
       "devDependencies": {
@@ -32,7 +33,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.16.0"
@@ -226,7 +226,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.15.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -255,7 +254,6 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.16.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.15.7",
@@ -1012,7 +1010,6 @@
     },
     "node_modules/@types/node": {
       "version": "17.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -1097,7 +1094,6 @@
     },
     "node_modules/acorn": {
       "version": "8.6.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1155,7 +1151,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -1311,6 +1306,11 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
       "dev": true,
@@ -1371,7 +1371,6 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -1434,7 +1433,6 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -1442,7 +1440,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1787,7 +1784,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -2080,7 +2076,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2390,6 +2385,38 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "license": "MIT"
@@ -2684,7 +2711,6 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -3280,6 +3306,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "17.0.2",
       "license": "MIT",
@@ -3487,6 +3521,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -3511,7 +3559,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -3550,6 +3597,14 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -3600,6 +3655,23 @@
         "decode-uri-component": "^0.2.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "dev": true,
@@ -3629,7 +3701,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -3642,6 +3713,36 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/terser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -4092,7 +4193,6 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.16.0",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.16.0"
       }
@@ -4218,8 +4318,7 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "dev": true
+      "version": "7.15.7"
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -4236,7 +4335,6 @@
     },
     "@babel/highlight": {
       "version": "7.16.0",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
@@ -4698,8 +4796,7 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.4",
-      "dev": true
+      "version": "17.0.4"
     },
     "@types/prop-types": {
       "version": "15.7.4"
@@ -4770,8 +4867,7 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.6.0",
-      "dev": true
+      "version": "8.6.0"
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -4804,7 +4900,6 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4897,6 +4992,11 @@
         "picocolors": "^1.0.0"
       }
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
     "builtin-modules": {
       "version": "3.2.0",
       "dev": true
@@ -4935,7 +5035,6 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4977,14 +5076,12 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "dev": true
+      "version": "1.1.3"
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5229,8 +5326,7 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "escodegen": {
       "version": "2.0.0",
@@ -5417,8 +5513,7 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -5605,6 +5700,31 @@
     "jest-get-type": {
       "version": "27.4.0",
       "dev": true
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "js-sha3": {
       "version": "0.8.0"
@@ -5814,8 +5934,7 @@
       }
     },
     "merge-stream": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "merge2": {
       "version": "1.4.1",
@@ -6180,6 +6299,14 @@
       "version": "1.2.3",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "react": {
       "version": "17.0.2",
       "requires": {
@@ -6296,6 +6423,17 @@
       "version": "2.2.2",
       "dev": true
     },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -6304,8 +6442,7 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "dev": true
+      "version": "5.1.2"
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -6333,6 +6470,14 @@
     "semver": {
       "version": "6.3.0",
       "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -6364,6 +6509,22 @@
         "decode-uri-component": "^0.2.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "dev": true
@@ -6381,7 +6542,6 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -6389,6 +6549,29 @@
     "symbol-tree": {
       "version": "3.2.4",
       "dev": true
+    },
+    "terser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "requires": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
     },
     "tiny-warning": {
       "version": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-query": "3.34.7",
+    "rollup-plugin-terser": "7.0.2",
     "vite-plugin-css-injected-by-js": "1.4.0"
   },
   "devDependencies": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { viteMockServe } from "vite-plugin-mock";
 import { rollupImportMapPlugin } from "rollup-plugin-import-map";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
+import { terser } from "rollup-plugin-terser";
 import { resolve } from "path";
 
 const reactUrl = "https://min-side-assets.dev.intern.nav.no/react/17/esm/index.js";
@@ -16,6 +17,7 @@ const imports = {
 export default ({ command }) => ({
   plugins: [
     react(),
+    terser(),
     cssInjectedByJsPlugin(),
     viteMockServe({
       mockPath: "mock",


### PR DESCRIPTION
Foreløpig er det ikke støtte for å skru på `minify` via esbuild i Vite. Derfor kan vi redusere størrelsen på bundle-en med rollup-plugin-terser.